### PR TITLE
Make sure hierarchy works

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ for ($i = 0; $i < 100; $i++) {
 
 $pool->hasItem('|users|4711|followers|12|likes'); // True
 
-$item = $pool->getItem('|users|4711|followers');
-$pool->deleteItem($item);
+$pool->deleteItem('|users|4711|followers');
 
 $pool->hasItem('|users|4711|followers|12|likes'); // False
 ```

--- a/tests/HierarchicalCachePoolTest.php
+++ b/tests/HierarchicalCachePoolTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of php-cache\apc-adapter package.
+ *
+ * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Cache\Hierarchy;
+
+use Cache\Adapter\Apc\ApcCachePool;
+use Cache\Adapter\PHPArray\ArrayCachePool;
+use Cache\IntegrationTests\CachePoolTest as BaseTest;
+
+class HierarchicalCachePoolTest  extends \PHPUnit_Framework_TestCase
+{
+    private $cache;
+
+    public function createCachePool()
+    {
+        return new HierarchicalCachePool($this->getCache());
+    }
+
+    public function getCache()
+    {
+        if ($this->cache === null) {
+            $this->cache = new ArrayCachePool();
+        }
+
+        return $this->cache;
+    }
+
+    public function testBasicUsage()
+    {
+        $pool = $this->createCachePool();
+        $user = 4711;
+        for ($i = 0; $i < 10; $i++) {
+            $item = $pool->getItem(sprintf('|users|%d|followers|%d|likes', $user, $i));
+            $item->set('Justin Bieber');
+            $pool->save($item);
+        }
+
+        $this->assertTrue($pool->hasItem('|users|4711|followers|4|likes'));
+        $pool->deleteItem('|users|4711|followers');
+        $this->assertFalse($pool->hasItem('|users|4711|followers|4|likes'));
+    }
+}

--- a/tests/IntegrationPoolTest.php
+++ b/tests/IntegrationPoolTest.php
@@ -11,11 +11,10 @@
 
 namespace Cache\Hierarchy;
 
-use Cache\Adapter\Apc\ApcCachePool;
 use Cache\Adapter\PHPArray\ArrayCachePool;
-use Cache\IntegrationTests\CachePoolTest as BaseTest;
+use Cache\IntegrationTests\CachePoolTest;
 
-class IntegrationPoolTest extends BaseTest
+class IntegrationPoolTest extends CachePoolTest
 {
     private $cache;
 

--- a/tests/IntegrationTagTest.php
+++ b/tests/IntegrationTagTest.php
@@ -11,7 +11,6 @@
 
 namespace Cache\Hierarchy;
 
-use Cache\Adapter\Apc\ApcCachePool;
 use Cache\Adapter\PHPArray\ArrayCachePool;
 use Cache\IntegrationTests\TaggableCachePoolTest;
 


### PR DESCRIPTION
This will implement a hierarchy using multiple lookups. An alternative is to move this functionality to the adapters. We could use redis built in hierarchy. 

`cache:::name0:::sub`
